### PR TITLE
Implement a simple cli using the same backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,7 @@ wayland-protocols = { version = "0.23", features = ["client", "unstable_protocol
 libpulse-binding = { version = "2.6.0"}
 dbus = "0.6"
 atty = "0.2"
+
+[[bin]]
+name = "wldash-cli"
+path = "src/cli.rs"


### PR DESCRIPTION
Add a wldash-cli command that uses the same backend to do changes from the command line. For now implement backlight manipulation.

As discussed on IRC this is the kind of thing I think would be useful to bring up a sway session easily. wldash already has all the code needed to manipulate backlight and sound so there's no reason for the user to have to fish around other commands to do the same from bindsym.

If this is acceptable I can work on fleshing it out:

- Adding sound stuff
- Moving the module organization into a `lib.rs` so both cli and gui can use it
- Improving the error handling