### PR TITLE
Fix build error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ mod draw;
 mod modules;
 mod app;
 
-use app::{App, Cmd};
+use crate::app::{App, Cmd};
 
 fn main() {
     let (mut rx_pipe, mut tx_pipe) = pipe().unwrap();


### PR DESCRIPTION
The command `cargo build` failed to run, because of the changes introduced with 4bc58623b79cb92f1bee913871d7f66db3c07673.