### PR TITLE
Match gnome product names like gedit

### DIFF
--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -16,6 +16,7 @@ pub struct Desktop {
     pub exec: Option<String>,
     pub url: Option<String>,
     pub term: bool,
+    pub gnome_product: Option<String>,
 }
 
 impl Desktop {
@@ -36,6 +37,7 @@ impl Desktop {
                 hidden: desktop.get("Hidden").unwrap_or(&"".to_string()) == "true",
                 exec: desktop.get("Exec").map(|x| x.to_string()),
                 url: desktop.get("URL").map(|x| x.to_string()),
+                gnome_product: desktop.get("X-GNOME-Bugzilla-Product").map(|x| x.to_string()),
             }),
             None => Err(Box::new(io_error::new(
                 ErrorKind::NotFound,

--- a/src/widgets/launcher.rs
+++ b/src/widgets/launcher.rs
@@ -80,7 +80,9 @@ impl Launcher {
             };
             let size = if idx == self.offset && self.input.len() > 0 {
                 let (_, indices) =
-                    fuzzy_indices(&m.name.to_lowercase(), &self.input.to_lowercase()).unwrap();
+                    fuzzy_indices(&m.name.to_lowercase(), &self.input.to_lowercase())
+                    .unwrap_or((0, vec![]));
+
                 let mut colors = Vec::with_capacity(m.name.len());
                 for pos in 0..m.name.len() {
                     if indices.contains(&pos) {
@@ -239,6 +241,16 @@ impl Widget for Launcher {
                     .filter(|(x, _)| x.is_some())
                     .map(|(x, y)| (x.unwrap(), y.clone()))
                     .collect::<Vec<(i64, Desktop)>>();
+
+                for desktop in self.options.iter() {
+                    let d = desktop.clone();
+                    if let Some(gnome_product) = &desktop.gnome_product {
+                        let fuzz = fuzzy_match(&gnome_product.to_lowercase(), &self.input.to_lowercase());
+                        if let Some(fuzz) = fuzz {
+                            m.push((fuzz, d));
+                        }
+                    }
+                }
 
                 m.sort_by(|(x1, y1), (x2, y2)| {
                     if x1 > x2 {


### PR DESCRIPTION
Use the X-GNOME-Bugzilla-Product property of desktop files to be able to match against "gedit" and not just "text editor".