### PR TITLE
Match on keywords in the launcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nix"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,8 +459,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rust-ini"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.14.0"
+source = "git+https://github.com/pedrocr/rust-ini.git?branch=no_eol_comments#70d2b56842d244d37a83c895dd345c122a0df218"
+dependencies = [
+ "multimap 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rusttype"
@@ -724,7 +735,7 @@ dependencies = [
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_pipe 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rcalc_lib 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-ini 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-ini 0.14.0 (git+https://github.com/pedrocr/rust-ini.git?branch=no_eol_comments)",
  "rusttype 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -789,6 +800,7 @@ dependencies = [
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+"checksum multimap 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1838fe05e64c53b9a62579020e4a12ec5947af5d703c56962d0e3b7b923bf3ba"
 "checksum nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
@@ -812,7 +824,7 @@ dependencies = [
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rcalc_lib 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2497fc2d7578e75282922918d96de8d4790714312900d95b6d5f577168f2656e"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum rust-ini 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
+"checksum rust-ini 0.14.0 (git+https://github.com/pedrocr/rust-ini.git?branch=no_eol_comments)" = "<none>"
 "checksum rusttype 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "654103d61a05074b268a107cf6581ce120f0fc0115f2610ed9dfea363bb81139"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ dbus = "0.6"
 fuzzy-matcher = "0.2"
 lazy_static = "1.4"
 rcalc_lib = { version = "0.9" }
-rust-ini = "0.13"
+rust-ini = { version = "0.14", git = "https://github.com/pedrocr/rust-ini.git", branch = "no_eol_comments"}
 shlex = "0.1"
 timerfd = "1.0.0"
 

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -16,6 +16,7 @@ pub struct Desktop {
     pub exec: Option<String>,
     pub url: Option<String>,
     pub term: bool,
+    pub keywords: Vec<String>,
 }
 
 impl Desktop {
@@ -36,6 +37,9 @@ impl Desktop {
                 hidden: desktop.get("Hidden").unwrap_or(&"".to_string()) == "true",
                 exec: desktop.get("Exec").map(|x| x.to_string()),
                 url: desktop.get("URL").map(|x| x.to_string()),
+                keywords: desktop.get("Keywords").map(|x|
+                    x.split(";").map(|y| y.trim().to_string()).filter(|z| z != "").collect()
+                ).unwrap_or(vec![]),
             }),
             None => Err(Box::new(io_error::new(
                 ErrorKind::NotFound,

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::io::Error as io_error;
 use std::io::ErrorKind;
 
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Debug, Eq, Hash)]
 pub struct Desktop {
     pub entry_type: String,
     pub name: String,

--- a/src/widgets/launcher.rs
+++ b/src/widgets/launcher.rs
@@ -232,24 +232,15 @@ impl Widget for Launcher {
 
                 for desktop in self.options.iter() {
                     let d = desktop.clone();
-                    m.push((
-                        fuzzy_match(&desktop.name.to_lowercase(), &self.input.to_lowercase()),
-                        d.clone(),
-                        100,
-                    ));
+                    if let Some(ma) = fuzzy_match(&desktop.name.to_lowercase(), &self.input.to_lowercase()) {
+                        m.push((ma, d.clone(), 100));
+                    }
                     for keyword in desktop.keywords.iter() {
-                        m.push((
-                            fuzzy_match(&keyword.to_lowercase(), &self.input.to_lowercase()),
-                            d.clone(),
-                            90,
-                        ));
+                        if let Some(ma) = fuzzy_match(&keyword.to_lowercase(), &self.input.to_lowercase()) {
+                            m.push((ma, d.clone(), 90));
+                        }
                     }
                 }
-
-                let mut m = m.iter()
-                    .filter(|(x, _, _)| x.is_some())
-                    .map(|(x, y, z)| (x.unwrap(), y.clone(), z.clone()))
-                    .collect::<Vec<(i64, Desktop, u64)>>();
 
                 m.sort_by(|(x1, y1, z1), (x2, y2, z2)| {
                     if z1 > z2 {

--- a/src/widgets/launcher.rs
+++ b/src/widgets/launcher.rs
@@ -235,22 +235,28 @@ impl Widget for Launcher {
                     m.push((
                         fuzzy_match(&desktop.name.to_lowercase(), &self.input.to_lowercase()),
                         d.clone(),
+                        100,
                     ));
                     for keyword in desktop.keywords.iter() {
                         m.push((
                             fuzzy_match(&keyword.to_lowercase(), &self.input.to_lowercase()),
                             d.clone(),
+                            90,
                         ));
                     }
                 }
 
                 let mut m = m.iter()
-                    .filter(|(x, _)| x.is_some())
-                    .map(|(x, y)| (x.unwrap(), y.clone()))
-                    .collect::<Vec<(i64, Desktop)>>();
+                    .filter(|(x, _, _)| x.is_some())
+                    .map(|(x, y, z)| (x.unwrap(), y.clone(), z.clone()))
+                    .collect::<Vec<(i64, Desktop, u64)>>();
 
-                m.sort_by(|(x1, y1), (x2, y2)| {
-                    if x1 > x2 {
+                m.sort_by(|(x1, y1, z1), (x2, y2, z2)| {
+                    if z1 > z2 {
+                        Ordering::Less
+                    } else if z2 > z1 {
+                        Ordering::Greater
+                    } else if x1 > x2 {
                         Ordering::Less
                     } else if x1 < x2 {
                         Ordering::Greater
@@ -263,7 +269,7 @@ impl Widget for Launcher {
                     }
                 });
 
-                self.matches = m.into_iter().map(|(_, x)| x).collect();
+                self.matches = m.into_iter().map(|(_, x, _)| x).collect();
             }
         };
 

--- a/src/widgets/launcher.rs
+++ b/src/widgets/launcher.rs
@@ -80,7 +80,8 @@ impl Launcher {
             };
             let size = if idx == self.offset && self.input.len() > 0 {
                 let (_, indices) =
-                    fuzzy_indices(&m.name.to_lowercase(), &self.input.to_lowercase()).unwrap();
+                    fuzzy_indices(&m.name.to_lowercase(), &self.input.to_lowercase())
+                    .unwrap_or((0, vec![]));
                 let mut colors = Vec::with_capacity(m.name.len());
                 for pos in 0..m.name.len() {
                     if indices.contains(&pos) {
@@ -227,15 +228,23 @@ impl Widget for Launcher {
             }
             Some('!') => (),
             _ => {
-                let mut m = self
-                    .options
-                    .iter()
-                    .map(|x| {
-                        (
-                            fuzzy_match(&x.name.to_lowercase(), &self.input.to_lowercase()),
-                            x,
-                        )
-                    })
+                let mut m = vec![];
+
+                for desktop in self.options.iter() {
+                    let d = desktop.clone();
+                    m.push((
+                        fuzzy_match(&desktop.name.to_lowercase(), &self.input.to_lowercase()),
+                        d.clone(),
+                    ));
+                    for keyword in desktop.keywords.iter() {
+                        m.push((
+                            fuzzy_match(&keyword.to_lowercase(), &self.input.to_lowercase()),
+                            d.clone(),
+                        ));
+                    }
+                }
+
+                let mut m = m.iter()
                     .filter(|(x, _)| x.is_some())
                     .map(|(x, y)| (x.unwrap(), y.clone()))
                     .collect::<Vec<(i64, Desktop)>>();


### PR DESCRIPTION
In the launcher match not only on the program name but also on the keywords specified in the desktop file.

Replaces #23 and depends on https://github.com/zonyitoo/rust-ini/pull/60