### PR TITLE
Add cursor to launcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +787,7 @@ dependencies = [
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smithay-client-toolkit 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "timerfd 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.23.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-protocols 0.23.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -896,6 +902,7 @@ dependencies = [
 "checksum ttf-parser 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52fbe7769f5af5d7d25aea74b9443b64e544a5ffb4d2b2968295ddea934f1a06"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum ucd-trie 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8f00ed7be0c1ff1e24f46c3d2af4859f7e863672ba3a6e92e7cff702bf9f06c2"
+"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ serde_yaml = { version = "0.8", optional = true }
 libpulse-binding = { version = "2.15", optional = true }
 alsa = { version = "0.4.0", optional = true }
 fontconfig = "0.2.0"
+unicode-segmentation = "1.6.0"

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -150,13 +150,17 @@ impl<'a> Font<'a> {
                 off = glyph.origin.1
             }
         }
+
+        let height = buf.get_bounds().3;
         for (i, glyph) in glyphs.iter().enumerate() {
-            glyph.draw(buf, (x_off, -off), bg, c);
-            x_off += glyph.dimensions.0 as i32 + glyph.origin.0;
-            if i + 1 == cursor {
-                let height = buf.get_bounds().3;
+            if i == cursor {
                 self.draw_cursor(buf, c, x_off as u32, height)?;
             }
+            glyph.draw(buf, (x_off, -off), bg, c);
+            x_off += glyph.dimensions.0 as i32 + glyph.origin.0;
+        }
+        if cursor == glyphs.len() {
+            self.draw_cursor(buf, c, x_off as u32, height)?;
         }
 
         Ok((x_off as u32, self.size as u32))

--- a/src/widgets/launcher.rs
+++ b/src/widgets/launcher.rs
@@ -75,22 +75,10 @@ impl<'a> Launcher<'a> {
                 Color::new(1.0, 1.0, 1.0, 1.0)
             };
 
-            let dim =
-                self.font
-                    .borrow_mut()
-                    .auto_draw_text(buf, bg, &c, &self.input[..self.cursor])?;
-
-            let cursor_placement = dim.0;
-            // draw cursor
-            for i in 1..self.font_size {
-                buf.put((cursor_placement, i), &Color::new(1.0, 1.0, 1.0, 1.0))
-                    .unwrap();
-            }
-
             let dim = self
                 .font
                 .borrow_mut()
-                .auto_draw_text(buf, bg, &c, &self.input)?;
+                .auto_draw_text_with_cursor(buf, bg, &c, &self.input, self.cursor)?;
 
             dim.0 + self.font_size / 4
         } else {
@@ -457,6 +445,7 @@ impl<'a> Widget for Launcher<'a> {
                 }
             }
             _ => {
+                println!("{}", key);
                 if let Some(v) = interpreted {
                     self.input.insert_str(self.cursor, &v);
                     self.cursor += 1;

--- a/src/widgets/launcher.rs
+++ b/src/widgets/launcher.rs
@@ -265,6 +265,7 @@ impl<'a> Widget for Launcher<'a> {
     fn enter(&mut self) {}
     fn leave(&mut self) {
         self.input = "".to_string();
+        self.cursor = 0;
         self.offset = 0;
         self.result = None;
         self.dirty = true;

--- a/src/widgets/launcher.rs
+++ b/src/widgets/launcher.rs
@@ -453,7 +453,6 @@ impl<'a> Widget for Launcher<'a> {
                 }
             }
             _ => {
-                println!("{}", key);
                 if let Some(v) = interpreted {
                     let indices: Vec<(usize, &str)> = self.input.grapheme_indices(true).collect();
                     if self.cursor == indices.len() {

--- a/src/widgets/launcher.rs
+++ b/src/widgets/launcher.rs
@@ -384,7 +384,6 @@ impl<'a> Widget for Launcher<'a> {
                         self.tx.send(Cmd::Exit).unwrap();
                     }
                     _ => {
-                        self.cursor = 0;
                         if self.matches.len() > self.offset {
                             let d = &self.matches[self.offset];
                             if let Some(exec) = &d.exec {

--- a/src/widgets/launcher.rs
+++ b/src/widgets/launcher.rs
@@ -75,10 +75,13 @@ impl<'a> Launcher<'a> {
                 Color::new(1.0, 1.0, 1.0, 1.0)
             };
 
-            let dim = self
-                .font
-                .borrow_mut()
-                .auto_draw_text_with_cursor(buf, bg, &c, &self.input, self.cursor)?;
+            let dim = self.font.borrow_mut().auto_draw_text_with_cursor(
+                buf,
+                bg,
+                &c,
+                &self.input,
+                self.cursor,
+            )?;
 
             dim.0 + self.font_size / 4
         } else {

--- a/src/widgets/launcher.rs
+++ b/src/widgets/launcher.rs
@@ -139,11 +139,12 @@ impl<'a> Launcher<'a> {
             + self.font_size / 4;
 
         let x_off = if !self.input.is_empty() {
-            let dim = self.font.borrow_mut().auto_draw_text(
+            let dim = self.font.borrow_mut().auto_draw_text_with_cursor(
                 &mut buf.offset((x_off, 0))?,
                 bg,
                 &Color::new(1.0, 1.0, 1.0, 1.0),
                 &self.input[1..],
+                self.cursor - 1,
             )?;
 
             x_off + dim.0 + self.font_size / 4
@@ -177,11 +178,12 @@ impl<'a> Launcher<'a> {
             + self.font_size / 4;
 
         if !self.input.is_empty() {
-            self.font.borrow_mut().auto_draw_text(
+            self.font.borrow_mut().auto_draw_text_with_cursor(
                 &mut buf.offset((x_off, 0))?,
                 bg,
                 &Color::new(1.0, 1.0, 1.0, 1.0),
                 &self.input[1..],
+                self.cursor - 1,
             )?;
         };
 

--- a/src/widgets/launcher.rs
+++ b/src/widgets/launcher.rs
@@ -408,13 +408,13 @@ impl<'a> Widget for Launcher<'a> {
                     }
                 };
             }
-            keysyms::XKB_KEY_Right => {
+            keysyms::XKB_KEY_Tab => {
                 if !self.matches.is_empty() && self.offset < self.matches.len() - 1 {
                     self.offset += 1;
                     self.dirty = true;
                 }
             }
-            keysyms::XKB_KEY_Left => {
+            keysyms::XKB_KEY_ISO_Left_Tab => {
                 if !self.matches.is_empty() && self.offset > 0 {
                     self.offset -= 1;
                     self.dirty = true;


### PR DESCRIPTION
Progress towards #14.

This PR adds a cursor, basic back-and-forth movements, as well as support for the delete key.

The following keybindings are affected:

|            | **Keybinding**                    | **Action**                |
| ---------- | --------------------------------- | ------------------------- |
| _Modified_ | <kbd>Tab</kbd>                    | Move selected match right |
| _Modified_ | <kbd>Shift</kbd> + <kbd>Tab</kbd> | Move selected match left  |
| _Modified_ | <kbd>Backspace</kbd>              | Remove left of cursor     |
| _Added_    | <kbd>Delete</kbd>                 | Remove right of cursor    |
| _Added_    | <kbd>Left</kbd>                   | Move cursor left          |
| _Added_    | <kbd>Right</kbd>                  | Move cursor right         |

**unicode_segmentation**:
I added a single dependency which handles the splitting of strings into grapheme clusters.

**TODO**:

- [ ] History file: In the referenced issue, the goal is to have a readline-style editor.
      Readline-style editors allow using <kbd>Up</kbd> and <kbd>Down</kbd> buttons to navigate previously used commands.
      We might want to add this in a separate PR. :shrug:
- [x] Correct UTF-8 parsing: Special characters like ÆØÅÞÐ are grapheme clusters, rather than individual characters.
      Indexing into the middle of a cluster is not handled correctly, so we need to ensure that the cursor is always at a cluster boundary, and that any removal removes the entire cluster.
