### PR TITLE
main: only bind up to version 3 of wl_output

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -400,7 +400,7 @@ impl<'a> App<'a> {
                     version,
                 } => {
                     if let "wl_output" = &interface[..] {
-                        let output = registry.bind(version, id);
+                        let output = registry.bind(std::cmp::min(version, 3), id);
                         inner_global.lock().unwrap().add_output(id, output);
                     }
                 }


### PR DESCRIPTION
I get a crash with the latest version of Sway otherwise.